### PR TITLE
Support multiValueHeaders on Response

### DIFF
--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -115,9 +115,20 @@ class HTTPCycle:
             and message_type == "http.response.start"
         ):
             self.response["statusCode"] = message["status"]
-            self.response["headers"] = {
-                k.decode().lower(): v.decode() for k, v in message.get("headers", [])
-            }
+            headers = {}
+            multi_value_headers = {}
+            for key, value in message.get("headers", []):
+                lower_key = key.decode().lower()
+                if lower_key in multi_value_headers:
+                    multi_value_headers[lower_key].append(value.decode())
+                elif lower_key in headers:
+                    multi_value_headers[lower_key] = [headers.pop(lower_key), value.decode()]
+                else:
+                    headers[lower_key] = value.decode()
+
+            self.response["headers"] = headers
+            if multi_value_headers:
+                self.response["multiValueHeaders"] = multi_value_headers
             self.state = HTTPCycleState.RESPONSE
 
         elif (

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -115,14 +115,17 @@ class HTTPCycle:
             and message_type == "http.response.start"
         ):
             self.response["statusCode"] = message["status"]
-            headers = {}
-            multi_value_headers = {}
+            headers: typing.Dict[str, str] = {}
+            multi_value_headers: typing.Dict[str, typing.List[str]] = {}
             for key, value in message.get("headers", []):
                 lower_key = key.decode().lower()
                 if lower_key in multi_value_headers:
                     multi_value_headers[lower_key].append(value.decode())
                 elif lower_key in headers:
-                    multi_value_headers[lower_key] = [headers.pop(lower_key), value.decode()]
+                    multi_value_headers[lower_key] = [
+                        headers.pop(lower_key),
+                        value.decode(),
+                    ]
                 else:
                     headers[lower_key] = value.decode()
 


### PR DESCRIPTION
@jordaneremieff 
I suggest to support  `multiValueHeaders` on Response.
I want to set the same-name cookies.
`FastAPI` + `uvicorn` can return same-name cookies.
But, Mangum returned only the last cookie. the first cookie is dropped.
Mangum should support `multiValueHeaders` to resolve the problem. 

This change affects a little bit of performance.
If You prefer this PR, then I will add test the code.

How do you think about it?

https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format


example
```python
from fastapi import FastAPI
from starlette.responses import Response
from mangum import Mangum
app = FastAPI()

@app.get('/')
def get_root():
    response = Response()
    response.set_cookie('test', 'value1')
    response.set_cookie('test', 'value2')
    return response


if __name__ == '__main__':
    import uvicorn
    uvicorn.run(app)
else:
    handler = Mangum(app)

```


output
```
curl -v http://127.0.0.1:8000/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< date: Tue, 23 Jun 2020 15:19:09 GMT
< server: uvicorn
< set-cookie: test=value1; Path=/; SameSite=lax
< set-cookie: test=value2; Path=/; SameSite=lax
< transfer-encoding: chunked
< 
* Connection #0 to host 127.0.0.1 left intact

```