### PR TITLE
Fix duplicate test names preventing test runs.

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -634,32 +634,6 @@ def test_api_request(mock_http_api_event) -> None:
 
 
 @pytest.mark.parametrize("mock_http_event", [["GET", "", None]], indirect=True)
-def test_http_response_headers(mock_http_event) -> None:
-    async def app(scope, receive, send):
-        assert scope["type"] == "http"
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": [[b"x-header-1", b"123"], [b"x-header-2", b"456"]],
-            }
-        )
-        await send({"type": "http.response.body", "body": b"Hello, world!"})
-
-    handler = Mangum(app, lifespan="off")
-
-    mock_http_event["headers"] = None
-
-    response = handler(mock_http_event, {})
-    assert response == {
-        "statusCode": 200,
-        "isBase64Encoded": False,
-        "headers": {"x-header-1": "123", "x-header-2": "456"},
-        "body": "Hello, world!",
-    }
-
-
-@pytest.mark.parametrize("mock_http_event", [["GET", "", None]], indirect=True)
 def test_http_empty_header(mock_http_event) -> None:
     async def app(scope, receive, send):
         assert scope["type"] == "http"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,12 +1,13 @@
 import base64
-import urllib.parse
-import json
 import gzip
+import json
+import urllib.parse
 
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.responses import PlainTextResponse
+
 from mangum import Mangum
 
 
@@ -115,7 +116,7 @@ def test_http_request(mock_http_event, query_string) -> None:
             "raw_path": None,
             "root_path": "",
             "scheme": "https",
-            "server": ("test.execute-api.us-west-2.amazonaws.com", 80),
+            "server": ("test.execute-api.us-west-2.amazonaws.com", 443),
             "type": "http",
         }
         await send(
@@ -545,7 +546,7 @@ def test_http_binary_gzip_response(mock_http_event) -> None:
     ],
     indirect=["mock_http_api_event"],
 )
-def test_http_request(mock_http_api_event) -> None:
+def test_api_request(mock_http_api_event) -> None:
     async def app(scope, receive, send):
         assert scope == {
             "asgi": {"version": "3.0"},


### PR DESCRIPTION
Hi there, this project is super cool! ❤️ 

While I was looking through the code, I noticed that there was a re-declaration of a test (`test_http_request` was declared twice in `test_http.py` \[[1](https://github.com/jordaneremieff/mangum/blob/f20dbda41567ba5e161a0f6db74c68311ae80c0a/tests/test_http.py#L26) [2](https://github.com/jordaneremieff/mangum/blob/f20dbda41567ba5e161a0f6db74c68311ae80c0a/tests/test_http.py#L548)\]) which was preventing one of the tests from running.

This PR renames the duplicate test and fixes the resulting test failure that was exposed!

Also, I noticed the `test_http_response_headers` test appears to be duplicated so I removed the duplicate.