### PR TITLE
Only prefix a slash on the api_gateway_base_path if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE Settings
+.idea/

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -84,7 +84,11 @@ class Mangum:
                 "Invalid argument supplied for `log_level`. "
                 "Choices are: critical|error|warning|info|debug"
             )
-        if self.api_gateway_base_path and not self.api_gateway_base_path.startswith("/"):
+        should_prefix_base_path = (
+            self.api_gateway_base_path
+            and not self.api_gateway_base_path.startswith("/")
+        )
+        if should_prefix_base_path:
             self.api_gateway_base_path = f"/{self.api_gateway_base_path}"
         if self.text_mime_types:
             self.text_mime_types = self.text_mime_types + DEFAULT_TEXT_MIME_TYPES

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -84,7 +84,7 @@ class Mangum:
                 "Invalid argument supplied for `log_level`. "
                 "Choices are: critical|error|warning|info|debug"
             )
-        if self.api_gateway_base_path:
+        if self.api_gateway_base_path and not self.api_gateway_base_path.startswith("/"):
             self.api_gateway_base_path = f"/{self.api_gateway_base_path}"
         if self.text_mime_types:
             self.text_mime_types = self.text_mime_types + DEFAULT_TEXT_MIME_TYPES

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pytest-cov
 black
 starlette
 quart; python_version == '3.7'
-dataclasses; python_version < '3.7'
 moto
 mypy
 


### PR DESCRIPTION
Only appends a prefix to the `api_gw_base_path` if it's not there already to avoid duplicate prefix slashes.

Issue: https://github.com/jordaneremieff/mangum/issues/137

Intended Design Change
```python3
api_gw_base_path = "prod"
api_gw_base_path = "/prod"

def lambda_handler(event, context):  # pragma: no cover
    handler = mangum.Mangum(api, api_gateway_base_path=settings.api_gw_base_path.lstrip("/"))  #137 Avoids the need for all consumers to call .lstrip("/") on their base path str
    response = handler(event, context)
    return response
```