### PR TITLE
Fix exception with ALB

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -97,9 +97,10 @@ class Mangum:
                 query_string = event.get("rawQueryString", "").encode()
             else:
                 source_ip = request_context.get("identity", {}).get("sourceIp")
-                multi_value_query_string_params = event[
-                    "multiValueQueryStringParameters"
-                ]
+                multi_value_query_string_params = event.get(
+                    "multiValueQueryStringParameters",
+                    None
+                )
                 query_string = (
                     urllib.parse.urlencode(
                         multi_value_query_string_params, doseq=True


### PR DESCRIPTION
Hi! 

When I`m using with ALB I got this exception:
```
[ERROR] KeyError: 'multiValueQueryStringParameters'
Traceback (most recent call last):
  File "/var/task/main.py", line 9, in handler
    response = asgi_handler(event, context) # Call the instance with the event arguments
  File "/var/task/mangum/adapter.py", line 118, in __call__
    multi_value_query_string_params = event[
```

I fix with custom handler
```python
def handler(event, context):
    if event.get('multiValueQueryStringParameters', False) is False:
        event['multiValueQueryStringParameters'] = None

    asgi_handler = Mangum(application)
    response = asgi_handler(event, context) # Call the instance with the event arguments

    return response
```

With ALB I received this event
```python
{
    "requestContext": {
        "elb": {
            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789:targetgroup/abc123456789cde0987654321/f6123456988320"
        }
    },
    "httpMethod": "POST",
    "path": "/",
    "queryStringParameters": {},
    "headers": {
        "accept": "*/*",
        "accept-encoding": "gzip, deflate, br",
        "cache-control": "no-cache",
        "connection": "keep-alive",
        "content-length": "57",
        "content-type": "application/json",
        "host": "test.execute-api.us-west-2.amazonaws.com",
        "postman-token": "abcd12-9d94-4939-b138-09dsakjc0s",
        "user-agent": "PostmanRuntime/7.26.5",
        "x-amzn-trace-id": "Root=1-5asdkjdsah-5ssakljdskljdsa29",
        "x-forwarded-for": "192.168.100.1, 192.168.1.1",
        "x-forwarded-port": "443",
        "x-forwarded-proto": "https"
    },
    "body": "{}",
    "isBase64Encoded": False
}
```
