### PR TITLE
Renaming and formatting

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -12,8 +12,10 @@ from .handlers import AbstractHandler
 from .protocols import HTTPCycle, LifespanCycle
 from .types import ASGIApp
 
+
 if TYPE_CHECKING:  # pragma: no cover
     from awslambdaric.lambda_context import LambdaContext
+
 
 DEFAULT_TEXT_MIME_TYPES = [
     "text/",
@@ -22,6 +24,7 @@ DEFAULT_TEXT_MIME_TYPES = [
     "application/xml",
     "application/vnd.api+json",
 ]
+
 
 logger = logging.getLogger("mangum")
 
@@ -34,8 +37,6 @@ class Mangum:
     specification. This will usually be an ASGI framework application instance.
     * **lifespan** - A string to configure lifespan support. Choices are `auto`, `on`,
     and `off`. Default is `auto`.
-    * **log_level** - A string to configure the log level. Choices are: `info`,
-    `critical`, `error`, `warning`, and `debug`. Default is `info`.
     * **text_mime_types** - A list of MIME types to include with the defaults that
     should not return a binary response in API Gateway.
     """
@@ -44,11 +45,8 @@ class Mangum:
     lifespan: str = "auto"
 
     def __init__(
-        self,
-        app: ASGIApp,
-        lifespan: str = "auto",
-        **handler_kwargs: Dict[str, Any],
-    ):
+        self, app: ASGIApp, lifespan: str = "auto", **handler_kwargs: Dict[str, Any]
+    ) -> None:
         self.app = app
         self.lifespan = lifespan
         self.handler_kwargs = handler_kwargs
@@ -69,7 +67,7 @@ class Mangum:
             handler = AbstractHandler.from_trigger(
                 event, context, **self.handler_kwargs
             )
-            http_cycle = HTTPCycle(handler.scope)
+            http_cycle = HTTPCycle(handler.request)
             response = http_cycle(self.app, handler.body)
 
         return handler.transform_response(response)

--- a/mangum/handlers/abstract_handler.py
+++ b/mangum/handlers/abstract_handler.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, TYPE_CHECKING, Tuple, List
 
 from .. import Response, Request
 
+
 if TYPE_CHECKING:  # pragma: no cover
     from awslambdaric.lambda_context import LambdaContext
 
@@ -20,7 +21,7 @@ class AbstractHandler(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def scope(self) -> Request:
+    def request(self) -> Request:
         """
         Parse an ASGI scope from the request event
         """

--- a/mangum/handlers/aws_alb.py
+++ b/mangum/handlers/aws_alb.py
@@ -17,7 +17,7 @@ class AwsAlb(AbstractHandler):
     TYPE = "AWS_ALB"
 
     @property
-    def scope(self) -> Request:
+    def request(self) -> Request:
         event = self.trigger_event
 
         headers = {}

--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, TYPE_CHECKING
 from .abstract_handler import AbstractHandler
 from .. import Response, Request
 
+
 if TYPE_CHECKING:  # pragma: no cover
     from awslambdaric.lambda_context import LambdaContext
 
@@ -30,7 +31,7 @@ class AwsApiGateway(AbstractHandler):
         self.base_path = base_path
 
     @property
-    def scope(self) -> Request:
+    def request(self) -> Request:
         event = self.trigger_event
 
         # multiValue versions of headers take precedence over their plain versions

--- a/mangum/handlers/aws_cf_lambda_at_edge.py
+++ b/mangum/handlers/aws_cf_lambda_at_edge.py
@@ -16,7 +16,7 @@ class AwsCfLambdaAtEdge(AbstractHandler):
     TYPE = "AWS_CF_LAMBDA_AT_EDGE"
 
     @property
-    def scope(self) -> Request:
+    def request(self) -> Request:
         event = self.trigger_event
 
         cf_request = event["Records"][0]["cf"]["request"]

--- a/mangum/handlers/aws_http_gateway.py
+++ b/mangum/handlers/aws_http_gateway.py
@@ -21,7 +21,7 @@ class AwsHttpGateway(AbstractHandler):
         return self.trigger_event.get("version", "")
 
     @property
-    def scope(self) -> Request:
+    def request(self) -> Request:
         event = self.trigger_event
 
         headers = {}

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -35,8 +35,8 @@ class HTTPCycle:
     """
     Manages the application cycle for an ASGI `http` connection.
 
-    * **scope** - A dictionary containing the connection scope used to run the ASGI
-    application instance.
+    * **request** - A request object containing the event and context for the connection
+    scope used to run the ASGI application instance.
     * **state** - An enumerated `HTTPCycleState` type that indicates the state of the
     ASGI connection.
     * **app_queue** - An asyncio queue (FIFO) containing messages to be received by the
@@ -44,7 +44,7 @@ class HTTPCycle:
     * **response** - A dictionary containing the response data to return in AWS Lambda.
     """
 
-    scope: Request
+    request: Request
     state: HTTPCycleState = HTTPCycleState.REQUEST
     response: Optional[Response] = None
 
@@ -78,7 +78,7 @@ class HTTPCycle:
         Calls the application with the `http` connection scope.
         """
         try:
-            await app(self.scope.as_dict(), self.receive, self.send)
+            await app(self.request.scope, self.receive, self.send)
         except BaseException as exc:
             self.logger.error("Exception in 'http' protocol.", exc_info=exc)
             if self.state is HTTPCycleState.REQUEST:

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -1,20 +1,32 @@
 import typing
 from dataclasses import dataclass, field
-from typing import List, Tuple, Dict, Any, Union, Optional, TYPE_CHECKING
-
+from typing import (
+    List,
+    Tuple,
+    Dict,
+    Any,
+    Union,
+    Optional,
+    MutableMapping,
+    Awaitable,
+    Callable,
+    TYPE_CHECKING,
+)
 from typing_extensions import Protocol
 
-Message = typing.MutableMapping[str, typing.Any]
-ScopeDict = typing.MutableMapping[str, typing.Any]
-Receive = typing.Callable[[], typing.Awaitable[Message]]
-Send = typing.Callable[[Message], typing.Awaitable[None]]
+
+Message = MutableMapping[str, Any]
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from awslambdaric.lambda_context import LambdaContext
 
 
 class ASGIApp(Protocol):
-    async def __call__(self, scope: ScopeDict, receive: Receive, send: Send) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         ...  # pragma: no cover
 
 
@@ -46,7 +58,8 @@ class Request:
     root_path: str = ""
     asgi: Dict[str, str] = field(default_factory=lambda: {"version": "3.0"})
 
-    def as_dict(self) -> ScopeDict:
+    @property
+    def scope(self) -> Scope:
         return {
             "type": self.type,
             "http_version": self.http_version,

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -1,4 +1,3 @@
-import typing
 from dataclasses import dataclass, field
 from typing import (
     List,

--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -74,7 +74,7 @@ def test_aws_alb_basic():
 
     example_context = {}
     handler = AwsAlb(example_event, example_context)
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": example_event,
@@ -171,7 +171,7 @@ def test_aws_alb_scope_real(
     if scope_path == "":
         scope_path = "/"
 
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": event,

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -224,7 +224,9 @@ def test_aws_api_gateway_scope_real(
 @pytest.mark.parametrize(
     "method,path,multi_value_query_parameters,req_body,body_base64_encoded,"
     "query_string,scope_body",
-    [("GET", "/test/hello", None, None, False, b"", None),],
+    [
+        ("GET", "/test/hello", None, None, False, b"", None),
+    ],
 )
 def test_aws_api_gateway_base_path(
     method,

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -96,7 +96,7 @@ def test_aws_api_gateway_scope_basic():
     }
     example_context = {}
     handler = AwsApiGateway(example_event, example_context)
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": example_event,
@@ -180,7 +180,7 @@ def test_aws_api_gateway_scope_real(
     if scope_path == "":
         scope_path = "/"
 
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": event,
@@ -224,9 +224,7 @@ def test_aws_api_gateway_scope_real(
 @pytest.mark.parametrize(
     "method,path,multi_value_query_parameters,req_body,body_base64_encoded,"
     "query_string,scope_body",
-    [
-        ("GET", "/test/hello", None, None, False, b"", None),
-    ],
+    [("GET", "/test/hello", None, None, False, b"", None),],
 )
 def test_aws_api_gateway_base_path(
     method,

--- a/tests/handlers/test_aws_cf_lambda_at_edge.py
+++ b/tests/handlers/test_aws_cf_lambda_at_edge.py
@@ -136,7 +136,7 @@ def test_aws_cf_lambda_at_edge_scope_basic():
     example_context = {}
     handler = AwsCfLambdaAtEdge(example_event, example_context)
 
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": example_event,
@@ -217,7 +217,7 @@ def test_aws_api_gateway_scope_real(
     example_context = {}
     handler = AwsCfLambdaAtEdge(event, example_context)
 
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": event,

--- a/tests/handlers/test_aws_http_gateway.py
+++ b/tests/handlers/test_aws_http_gateway.py
@@ -195,7 +195,7 @@ def test_aws_http_gateway_scope_basic_v1():
     }
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": example_event,
@@ -225,7 +225,7 @@ def test_aws_http_gateway_scope_v1_only_non_multi_headers():
     del example_event["multiValueQueryStringParameters"]
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
-    assert handler.scope.as_dict()["query_string"] == b"hello=world"
+    assert handler.request.scope["query_string"] == b"hello=world"
 
 
 def test_aws_http_gateway_scope_v1_no_headers():
@@ -239,7 +239,7 @@ def test_aws_http_gateway_scope_v1_no_headers():
     del example_event["queryStringParameters"]
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
-    assert handler.scope.as_dict()["query_string"] == b""
+    assert handler.request.scope["query_string"] == b""
 
 
 def test_aws_http_gateway_scope_basic_v2():
@@ -297,7 +297,7 @@ def test_aws_http_gateway_scope_basic_v2():
     }
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": example_event,
@@ -332,7 +332,7 @@ def test_aws_http_gateway_scope_bad_version():
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
     with pytest.raises(RuntimeError):
-        handler.scope.as_dict()
+        handler.request.scope
 
 
 @pytest.mark.parametrize(
@@ -373,7 +373,7 @@ def test_aws_http_gateway_scope_real_v1(
     if scope_path == "":
         scope_path = "/"
 
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": event,
@@ -437,7 +437,7 @@ def test_aws_http_gateway_scope_real_v2(
     if scope_path == "":
         scope_path = "/"
 
-    assert handler.scope.as_dict() == {
+    assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
         "aws.event": event,
@@ -508,11 +508,7 @@ def test_aws_http_gateway_response_v1(
             headers.append([b"content-type", content_type])
 
         await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": headers,
-            }
+            {"type": "http.response.start", "status": 200, "headers": headers,}
         )
         await send({"type": "http.response.body", "body": raw_res_body})
 
@@ -575,11 +571,7 @@ def test_aws_http_gateway_response_v2(
             headers.append([b"content-type", content_type])
 
         await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": headers,
-            }
+            {"type": "http.response.start", "status": 200, "headers": headers,}
         )
         await send({"type": "http.response.body", "body": raw_res_body})
 

--- a/tests/handlers/test_aws_http_gateway.py
+++ b/tests/handlers/test_aws_http_gateway.py
@@ -508,7 +508,11 @@ def test_aws_http_gateway_response_v1(
             headers.append([b"content-type", content_type])
 
         await send(
-            {"type": "http.response.start", "status": 200, "headers": headers,}
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": headers,
+            }
         )
         await send({"type": "http.response.body", "body": raw_res_body})
 
@@ -571,7 +575,11 @@ def test_aws_http_gateway_response_v2(
             headers.append([b"content-type", content_type])
 
         await send(
-            {"type": "http.response.start", "status": 200, "headers": headers,}
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": headers,
+            }
         )
         await send({"type": "http.response.body", "body": raw_res_body})
 


### PR DESCRIPTION
Renamed `scope` to `request` in the handler classes, accessing scope as a single type on the request, adjusted docstrings, removed typing import, some minor formatting changes - no changes to behavior.

Docs probably need updates but this can be done prior to next release.