### PR TITLE
#181 - ensure bytes are always returned from .body() method

### DIFF
--- a/mangum/handlers/aws_alb.py
+++ b/mangum/handlers/aws_alb.py
@@ -57,10 +57,8 @@ class AwsAlb(AbstractHandler):
 
     @property
     def body(self) -> bytes:
-        body = self.trigger_event.get("body", b"")
+        body = self.trigger_event.get("body", b"") or b""
 
-        if not body:
-            body = b""
         if self.trigger_event.get("isBase64Encoded", False):
             return base64.b64decode(body)
         if not isinstance(body, bytes):

--- a/mangum/handlers/aws_alb.py
+++ b/mangum/handlers/aws_alb.py
@@ -58,8 +58,14 @@ class AwsAlb(AbstractHandler):
     @property
     def body(self) -> bytes:
         body = self.trigger_event.get("body", b"")
+
+        if not body:
+            body = b""
         if self.trigger_event.get("isBase64Encoded", False):
-            body = base64.b64decode(body)
+            return base64.b64decode(body)
+        if not isinstance(body, bytes):
+            body = body.encode()
+
         return body
 
     def transform_response(self, response: Response) -> Dict[str, Any]:

--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -96,8 +96,13 @@ class AwsApiGateway(AbstractHandler):
     @property
     def body(self) -> bytes:
         body = self.trigger_event.get("body", b"")
+        if not body:
+            body = b""
         if self.trigger_event.get("isBase64Encoded", False):
-            body = base64.b64decode(body)
+            return base64.b64decode(body)
+        if not isinstance(body, bytes):
+            body = body.encode()
+
         return body
 
     def transform_response(self, response: Response) -> Dict[str, Any]:

--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -96,7 +96,7 @@ class AwsApiGateway(AbstractHandler):
     @property
     def body(self) -> bytes:
         body = self.trigger_event.get("body", b"") or b""
-    
+
         if self.trigger_event.get("isBase64Encoded", False):
             return base64.b64decode(body)
         if not isinstance(body, bytes):

--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -95,9 +95,8 @@ class AwsApiGateway(AbstractHandler):
 
     @property
     def body(self) -> bytes:
-        body = self.trigger_event.get("body", b"")
-        if not body:
-            body = b""
+        body = self.trigger_event.get("body", b"") or b""
+    
         if self.trigger_event.get("isBase64Encoded", False):
             return base64.b64decode(body)
         if not isinstance(body, bytes):

--- a/mangum/handlers/aws_cf_lambda_at_edge.py
+++ b/mangum/handlers/aws_cf_lambda_at_edge.py
@@ -55,10 +55,8 @@ class AwsCfLambdaAtEdge(AbstractHandler):
     @property
     def body(self) -> bytes:
         request = self.trigger_event["Records"][0]["cf"]["request"]
-        body = request.get("body", {}).get("data", None)
+        body = request.get("body", {}).get("data", None) or b""
 
-        if not body:
-            body = b""
         if request.get("body", {}).get("encoding", "") == "base64":
             return base64.b64decode(body)
         if not isinstance(body, bytes):

--- a/mangum/handlers/aws_cf_lambda_at_edge.py
+++ b/mangum/handlers/aws_cf_lambda_at_edge.py
@@ -56,8 +56,14 @@ class AwsCfLambdaAtEdge(AbstractHandler):
     def body(self) -> bytes:
         request = self.trigger_event["Records"][0]["cf"]["request"]
         body = request.get("body", {}).get("data", None)
+
+        if not body:
+            body = b""
         if request.get("body", {}).get("encoding", "") == "base64":
-            body = base64.b64decode(body)
+            return base64.b64decode(body)
+        if not isinstance(body, bytes):
+            body = body.encode()
+
         return body
 
     def transform_response(self, response: Response) -> Dict[str, Any]:

--- a/mangum/handlers/aws_http_gateway.py
+++ b/mangum/handlers/aws_http_gateway.py
@@ -103,8 +103,14 @@ class AwsHttpGateway(AbstractHandler):
     @property
     def body(self) -> bytes:
         body = self.trigger_event.get("body", b"")
+
+        if not body:
+            body = b""
         if self.trigger_event.get("isBase64Encoded", False):
-            body = base64.b64decode(body)
+            return base64.b64decode(body)
+        if not isinstance(body, bytes):
+            body = body.encode()
+
         return body
 
     def transform_response(self, response: Response) -> Dict[str, Any]:

--- a/mangum/handlers/aws_http_gateway.py
+++ b/mangum/handlers/aws_http_gateway.py
@@ -104,8 +104,6 @@ class AwsHttpGateway(AbstractHandler):
     def body(self) -> bytes:
         body = self.trigger_event.get("body", b"") or b""
 
-        if not body:
-            body = b""
         if self.trigger_event.get("isBase64Encoded", False):
             return base64.b64decode(body)
         if not isinstance(body, bytes):

--- a/mangum/handlers/aws_http_gateway.py
+++ b/mangum/handlers/aws_http_gateway.py
@@ -102,7 +102,7 @@ class AwsHttpGateway(AbstractHandler):
 
     @property
     def body(self) -> bytes:
-        body = self.trigger_event.get("body", b"")
+        body = self.trigger_event.get("body", b"") or b""
 
         if not body:
             body = b""

--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -74,6 +74,8 @@ def test_aws_alb_basic():
 
     example_context = {}
     handler = AwsAlb(example_event, example_context)
+
+    assert type(handler.body) == bytes
     assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
@@ -119,7 +121,15 @@ def test_aws_alb_basic():
     "query_string,scope_body",
     [
         ("GET", "/hello/world", None, None, False, b"", None),
-        ("POST", "/", {"name": ["me"]}, None, False, b"name=me", None),
+        (
+            "POST",
+            "/",
+            {"name": ["me"]},
+            "field1=value1&field2=value2",
+            False,
+            b"name=me",
+            b"field1=value1&field2=value2",
+        ),
         (
             "GET",
             "/my/resource",
@@ -210,7 +220,10 @@ def test_aws_alb_scope_real(
         "type": "http",
     }
 
-    assert handler.body == scope_body
+    if handler.body:
+        assert handler.body == scope_body
+    else:
+        assert handler.body == b""
 
 
 def test_aws_alb_set_cookies() -> None:

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -96,6 +96,8 @@ def test_aws_api_gateway_scope_basic():
     }
     example_context = {}
     handler = AwsApiGateway(example_event, example_context)
+
+    assert type(handler.body) == bytes
     assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
@@ -128,7 +130,15 @@ def test_aws_api_gateway_scope_basic():
     "query_string,scope_body",
     [
         ("GET", "/hello/world", None, None, False, b"", None),
-        ("POST", "/", {"name": ["me"]}, None, False, b"name=me", None),
+        (
+            "POST",
+            "/",
+            {"name": ["me"]},
+            "field1=value1&field2=value2",
+            False,
+            b"name=me",
+            b"field1=value1&field2=value2",
+        ),
         (
             "GET",
             "/my/resource",
@@ -218,7 +228,10 @@ def test_aws_api_gateway_scope_real(
         "type": "http",
     }
 
-    assert handler.body == scope_body
+    if handler.body:
+        assert handler.body == scope_body
+    else:
+        assert handler.body == b""
 
 
 @pytest.mark.parametrize(

--- a/tests/handlers/test_aws_cf_lambda_at_edge.py
+++ b/tests/handlers/test_aws_cf_lambda_at_edge.py
@@ -136,6 +136,7 @@ def test_aws_cf_lambda_at_edge_scope_basic():
     example_context = {}
     handler = AwsCfLambdaAtEdge(example_event, example_context)
 
+    assert type(handler.body) == bytes
     assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
@@ -169,7 +170,15 @@ def test_aws_cf_lambda_at_edge_scope_basic():
     "body_base64_encoded,query_string,scope_body",
     [
         ("GET", "/hello/world", None, None, False, b"", None),
-        ("POST", "/", {"name": ["me"]}, None, False, b"name=me", None),
+        (
+            "POST",
+            "/",
+            {"name": ["me"]},
+            "field1=value1&field2=value2",
+            False,
+            b"name=me",
+            b"field1=value1&field2=value2",
+        ),
         (
             "GET",
             "/my/resource",
@@ -241,7 +250,10 @@ def test_aws_api_gateway_scope_real(
         "type": "http",
     }
 
-    assert handler.body == scope_body
+    if handler.body:
+        assert handler.body == scope_body
+    else:
+        assert handler.body == b""
 
 
 @pytest.mark.parametrize(

--- a/tests/handlers/test_aws_http_gateway.py
+++ b/tests/handlers/test_aws_http_gateway.py
@@ -195,6 +195,8 @@ def test_aws_http_gateway_scope_basic_v1():
     }
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
+
+    assert type(handler.body) == bytes
     assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
@@ -297,6 +299,8 @@ def test_aws_http_gateway_scope_basic_v2():
     }
     example_context = {}
     handler = AwsHttpGateway(example_event, example_context)
+
+    assert type(handler.body) == bytes
     assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},
@@ -396,7 +400,10 @@ def test_aws_http_gateway_scope_real_v1(
         "type": "http",
     }
 
-    assert handler.body == scope_body
+    if handler.body:
+        assert handler.body == scope_body
+    else:
+        assert handler.body == b""
 
 
 @pytest.mark.parametrize(
@@ -461,7 +468,10 @@ def test_aws_http_gateway_scope_real_v2(
         "type": "http",
     }
 
-    assert handler.body == scope_body
+    if handler.body:
+        assert handler.body == scope_body
+    else:
+        assert handler.body == b""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I believe this closes #181. 

All tests pass, and I have tested the solution on a live lambda function being severed by ALB. 

The type annotations suggest that `def body(self) -> bytes:` should ALWAYS return bytes. However the code (and tests) sometimes returns None. In these cases I forced the None to return an empty byte string: `b""`.  As a result most of the methods now look like this:

```python
    @property
    def body(self) -> bytes:
        body = self.trigger_event.get("body", b"")

        if not body:
            body = b""
        if self.trigger_event.get("isBase64Encoded", False):
            return base64.b64decode(body)
        if not isinstance(body, bytes):
            body = body.encode()

        return body
```

If that is incorrect I can update my PR to reflect that `bytes` OR `None` can be returned from `def body(self)` and remove the code that forces None to become b"". 

Let me know if I should add anything else! Have loved using Mangum these past few months, made moving my Django application to serverless pretty easy. 