### PR TITLE
#178 alb url double encoding

### DIFF
--- a/mangum/handlers/aws_alb.py
+++ b/mangum/handlers/aws_alb.py
@@ -23,7 +23,7 @@ class AwsAlb(AbstractHandler):
         The parameters must be decoded, and then encoded again to prevent double
         encoding.
 
-        See: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html
+        See: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html  # noqa: E501
         "If the query parameters are URL-encoded, the load balancer does not decode
         them. You must decode them in your Lambda function."
 

--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -52,7 +52,7 @@ def test_aws_alb_basic():
         },
         "httpMethod": "GET",
         "path": "/lambda",
-        "queryStringParameters": {"query": "1234ABCD"},
+        "queryStringParameters": {"query": "1234ABCD", "a": "b%20c"},
         "headers": {
             "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,"
             "image/webp,image/apng,*/*;q=0.8",
@@ -74,6 +74,13 @@ def test_aws_alb_basic():
 
     example_context = {}
     handler = AwsAlb(example_event, example_context)
+    print(
+        f"wrong? "
+        f"{example_event['queryStringParameters']}"
+        f" -> "
+        f"{handler.request.scope['query_string']}"
+    )
+    # wrong? {'query': '1234ABCD', 'a': 'b%20c'} -> b'query=1234ABCD&a=b%2520c'
     assert handler.request.scope == {
         "asgi": {"version": "3.0"},
         "aws.context": {},

--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -111,7 +111,7 @@ def test_aws_alb_basic():
         "http_version": "1.1",
         "method": "GET",
         "path": "/lambda",
-        "query_string": b"q1=1234ABCD&q2=b+c&q3=b+c&q4=%2Fsome%2Fpath%2F&q5=%2Fsome%2Fpath%2F",
+        "query_string": b"q1=1234ABCD&q2=b+c&q3=b+c&q4=%2Fsome%2Fpath%2F&q5=%2Fsome%2Fpath%2F",  # noqa: E501
         "raw_path": None,
         "root_path": "",
         "scheme": "http",

--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -54,7 +54,7 @@ def test_aws_alb_basic():
         "path": "/lambda",
         "queryStringParameters": {
             "q1": "1234ABCD",
-            "q2": "b+c",  # not encoded
+            "q2": "b c",  # not encoded
             "q3": "b%20c",  # encoded
             "q4": "/some/path/",  # not encoded
             "q5": "%2Fsome%2Fpath%2F",  # encoded


### PR DESCRIPTION
I believe this closes #178. See the issue for a discussion of the bug. Tests pass, and I have tested this on a lambda function being served by an ALB. 


In short: "If the query parameters are URL-encoded, the load balancer does not decode them. You must decode them in your Lambda function."
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html

Thanks to @jurasofish for initially finding the issue and writing the failing test. This PR includes his commit from https://github.com/jordaneremieff/mangum/pull/179, which can be closed if this PR is merged. 

I don't know if something similar needs to be applied to the other handlers, not as familiar / not using those trigger methods. 