### PR TITLE
add test to return multiple headers when the multi-value headers opton is enabled in ALB

### DIFF
--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -321,7 +321,7 @@ def test_aws_alb_set_cookies_headers_multivalue() -> None:
         "statusCode": 200,
         "isBase64Encoded": False,
         "multiValueHeaders": {
-            "content-type": "text/plain; charset=utf-8",
+            "content-type": ["text/plain; charset=utf-8"],
             "set-cookie": ["cookie1=cookie1; Secure", "cookie2=cookie2; Secure"],
         },
         "headers": {},

--- a/tests/handlers/test_aws_alb.py
+++ b/tests/handlers/test_aws_alb.py
@@ -297,6 +297,38 @@ def test_aws_alb_set_cookies_headers() -> None:
     }
 
 
+def test_aws_alb_set_cookies_headers_multivalue() -> None:
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    [b"content-type", b"text/plain; charset=utf-8"],
+                    [b"set-cookie", b"cookie1=cookie1; Secure"],
+                    [b"set-cookie", b"cookie2=cookie2; Secure"],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+    handler = Mangum(app, lifespan="off")
+    event = get_mock_aws_alb_event(
+        "GET", "/test", {}, None, False, multi_value_headers=True
+    )
+    response = handler(event, {})
+    assert response == {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "multiValueHeaders": {
+            "content-type": "text/plain; charset=utf-8",
+            "set-cookie": ["cookie1=cookie1; Secure", "cookie2=cookie2; Secure"],
+        },
+        "headers": {},
+        "body": "Hello, world!",
+    }
+
+
 @pytest.mark.parametrize(
     "method,content_type,raw_res_body,res_body,res_base64_encoded",
     [


### PR DESCRIPTION
mangum splits the header response between the `headers` and `multiValueHeaders` items.

When the multi-value headers option is enabled all headers must be under `multiValueHeaders`, as described here https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers.

What mangum produces: 
```
'headers': {'content-type': 'text/plain; charset=utf-8'}, 'multiValueHeaders': {'set-cookie': ['cookie1=cookie1; Secure', 'cookie2=cookie2; Secure']}
```
What should be produced:
```
'multiValueHeaders': {'content-type': ['text/plain; charset=utf-8'], 'set-cookie': ['cookie1=cookie1; Secure', 'cookie2=cookie2; Secure']}
```
