### PR TITLE
Revert "base_path" -> "api_gateway_base_path"

### DIFF
--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -24,11 +24,11 @@ class AwsApiGateway(AbstractHandler):
         self,
         trigger_event: Dict[str, Any],
         trigger_context: "LambdaContext",
-        base_path: str = "/",
+        api_gateway_base_path: str = "/",
         **kwargs: Dict[str, Any],  # type: ignore
     ):
         super().__init__(trigger_event, trigger_context, **kwargs)
-        self.base_path = base_path
+        self.api_gateway_base_path = api_gateway_base_path
 
     @property
     def request(self) -> Request:
@@ -74,11 +74,11 @@ class AwsApiGateway(AbstractHandler):
 
         if not path:
             path = "/"
-        elif self.base_path and self.base_path != "/":
-            if not self.base_path.startswith("/"):
-                self.base_path = f"/{self.base_path}"
-            if path.startswith(self.base_path):
-                path = path[len(self.base_path) :]
+        elif self.api_gateway_base_path and self.api_gateway_base_path != "/":
+            if not self.api_gateway_base_path.startswith("/"):
+                self.api_gateway_base_path = f"/{self.api_gateway_base_path}"
+            if path.startswith(self.api_gateway_base_path):
+                path = path[len(self.api_gateway_base_path) :]
 
         return Request(
             method=http_method,

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -266,7 +266,7 @@ def test_aws_api_gateway_base_path(
         )
         await send({"type": "http.response.body", "body": b"Hello world!"})
 
-    handler = Mangum(app, lifespan="off", base_path=None)
+    handler = Mangum(app, lifespan="off", api_gateway_base_path=None)
     response = handler(event, {})
 
     assert response == {
@@ -292,7 +292,7 @@ def test_aws_api_gateway_base_path(
         await send({"type": "http.response.body", "body": b"Hello world!"})
 
     api_gateway_base_path = "test"
-    handler = Mangum(app, lifespan="off", base_path=api_gateway_base_path)
+    handler = Mangum(app, lifespan="off", api_gateway_base_path=api_gateway_base_path)
     response = handler(event, {})
     assert response == {
         "body": "Hello world!",


### PR DESCRIPTION
All of the previous releases use `api_gateway_base_path`, reverting the name change.