### PR TITLE
Exclude tests from find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def get_long_description():
 setup(
     name="mangum",
     version="0.12.1",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     license="MIT",
     url="https://github.com/jordaneremieff/mangum",
     description="AWS Lambda & API Gateway support for ASGI",


### PR DESCRIPTION
closes #194 

Necessary after https://github.com/jordaneremieff/mangum/pull/170
added a `tests/__init__.py` file that lead `find_packages` to treat
`tests`as a package dir, which will clobber `mangum` users' ability
to import from a repo-local `tests` directory.