### PR TITLE
handle host headers with trailing :

### DIFF
--- a/mangum/handlers/aws_alb.py
+++ b/mangum/handlers/aws_alb.py
@@ -121,7 +121,7 @@ class AwsAlb(AbstractHandler):
             server_port = uq_headers.get("x-forwarded-port", 80)
         else:
             server_name, server_port = server_name.split(":")  # pragma: no cover
-        server = (server_name, int(server_port))
+        server = (server_name, int(server_port or 80))
         client = (source_ip, 0)
 
         if not path:

--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -69,7 +69,7 @@ class AwsApiGateway(AbstractHandler):
             server_port = headers.get("x-forwarded-port", 80)
         else:
             server_name, server_port = server_name.split(":")  # pragma: no cover
-        server = (server_name, int(server_port))
+        server = (server_name, int(server_port or 80))
         client = (source_ip, 0)
 
         if not path:

--- a/mangum/handlers/aws_cf_lambda_at_edge.py
+++ b/mangum/handlers/aws_cf_lambda_at_edge.py
@@ -31,7 +31,7 @@ class AwsCfLambdaAtEdge(AbstractHandler):
             server_port = forwarded_port_header[0].get("value", 80)
         else:
             server_name, server_port = server_name.split(":")  # pragma: no cover
-        server = (server_name, int(server_port))
+        server = (server_name, int(server_port or 80))
 
         source_ip = cf_request["clientIp"]
         client = (source_ip, 0)

--- a/mangum/handlers/aws_http_gateway.py
+++ b/mangum/handlers/aws_http_gateway.py
@@ -81,7 +81,7 @@ class AwsHttpGateway(AwsApiGateway):
             server_port = headers.get("x-forwarded-port", 80)
         else:
             server_name, server_port = server_name.split(":")  # pragma: no cover
-        server = (server_name, int(server_port))
+        server = (server_name, int(server_port or 80))
         client = (source_ip, 0)
 
         if not path:

--- a/mangum/handlers/aws_ws_gateway.py
+++ b/mangum/handlers/aws_ws_gateway.py
@@ -25,7 +25,7 @@ def get_server_and_headers(event: dict) -> Tuple:  # pragma: no cover
         server_port = headers.get("x-forwarded-port", 80)
     else:
         server_name, server_port = server_name.split(":")
-    server = (server_name, int(server_port))
+    server = (server_name, int(server_port or 80))
 
     return server, headers
 


### PR DESCRIPTION
The handlers currently crash if the host header has a trailing `:` (for example `example.com:`).  Ideally this header would still propagate down so we can return a user error (4XX) for an invalid host header.