### PR TITLE
Gracefully hanlde exceptions that happen after successful request.

### DIFF
--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -80,6 +80,13 @@ class HTTPCycle:
         try:
             await app(self.request.scope, self.receive, self.send)
         except BaseException as exc:
+            if self.state is HTTPCycleState.COMPLETE:
+                # We want to log, but skip exceptions from background tasks
+                self.logger.exception(
+                    "An exception has occurred after successful completion of request"
+                )
+                return
+
             self.logger.error("Exception in 'http' protocol.", exc_info=exc)
             if self.state is HTTPCycleState.REQUEST:
                 await self.send(


### PR DESCRIPTION
With the current implementation, any exception in the ASGI app will
make mangum return a response with 500, even though the application may
have already correctly generated a valid response. In those cases we
want to return the valid response and log the error, rather than fail.

One example where this would manifest: failures in BackgroundTasks in
FastAPI.

This makes it inline with running FastAPI (and other ASGI) applications
standalone where failures in the background tasks will return not make
the whole request fail.