### PR TITLE
Added explicit python3.9 and 3.10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest-cov
 black
 flake8
 starlette
-quart; python_version == '3.7'
+quart; python_version >= '3.7'
 moto[server]
 mypy
 brotli

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -12,9 +12,9 @@ from mangum.exceptions import LifespanFailure
 IS_PY36 = sys.version_info[:2] == (3, 6)
 
 if not IS_PY36:
-    Quart = None
-else:
     from quart import Quart
+else:
+    Quart = None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -8,14 +8,13 @@ from starlette.responses import PlainTextResponse
 from mangum import Mangum
 from mangum.exceptions import LifespanFailure
 
-# One (or more) of Quart's dependencies does not support Python 3.8, ignore this case.
-IS_PY38 = sys.version_info[:2] == (3, 8)
+# Quart no longer support python3.6.
 IS_PY36 = sys.version_info[:2] == (3, 6)
 
-if not (IS_PY38 or IS_PY36):
-    from quart import Quart
-else:
+if not IS_PY36:
     Quart = None
+else:
+    from quart import Quart
 
 
 @pytest.mark.parametrize(
@@ -269,9 +268,6 @@ def test_starlette_lifespan(mock_aws_api_gateway_event) -> None:
     }
 
 
-@pytest.mark.skipif(
-    IS_PY38, reason="One (or more) of Quart's dependencies does not support Python 3.8."
-)
 @pytest.mark.skipif(IS_PY36, reason="Quart does not support Python 3.6.")
 @pytest.mark.parametrize(
     "mock_aws_api_gateway_event", [["GET", None, None]], indirect=True


### PR DESCRIPTION
- Added python3.9 and 3.10 tests to CI
- Added python3.9 and 3.10 classifiers to `setup.py`
- Changed `Quart` python version constraint, Quart now supports python 3.7 and above
- Adjusted tests to reflect the Quart version change