### PR TITLE
Fix aws_api_gateway handler not accepting combined headers and multiValueHeaders

### DIFF
--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -45,10 +45,12 @@ class AwsApiGateway(AbstractHandler):
         # This overrides headers that have the same name
         # That means that multiValue versions of headers take precedence over their plain versions
         if event.get("multiValueHeaders"):
-            headers.update({
-                k.lower(): ", ".join(v) if isinstance(v, list) else ""
-                for k, v in event.get("multiValueHeaders", {}).items()
-            })
+            headers.update(
+                {
+                    k.lower(): ", ".join(v) if isinstance(v, list) else ""
+                    for k, v in event.get("multiValueHeaders", {}).items()
+                }
+            )
 
         request_context = event["requestContext"]
 

--- a/mangum/handlers/aws_api_gateway.py
+++ b/mangum/handlers/aws_api_gateway.py
@@ -43,7 +43,8 @@ class AwsApiGateway(AbstractHandler):
             headers.update({k.lower(): v for k, v in event.get("headers", {}).items()})
         # Read multiValueHeaders
         # This overrides headers that have the same name
-        # That means that multiValue versions of headers take precedence over their plain versions
+        # That means that multiValue versions of headers take precedence
+        # over their plain versions
         if event.get("multiValueHeaders"):
             headers.update(
                 {

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -105,13 +105,11 @@ def test_aws_api_gateway_scope_basic():
         "aws.eventType": "AWS_API_GATEWAY",
         "client": (None, 0),
         "headers": [
-            [
-                b"accept",
-                b"text/html,application/xhtml+xml,application/xml;q=0.9,"
-                b"image/webp,image/apng,*/*;q=0.8,"
-                b"application/signed-exchange;v=b3;q=0.9",
-            ],
+            [b"accept", b"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"],  # noqa: E501
             [b"accept-encoding", b"gzip, deflate, br"],
+            [b"host", b"70ixmpl4fl.execute-api.us-east-2.amazonaws.com"],
+            [b"user-agent", b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"],  # noqa: E501
+            [b"x-amzn-trace-id", b"Root=1-5e66d96f-7491f09xmpl79d18acf3d050"]
         ],
         "http_version": "1.1",
         "method": "GET",
@@ -120,7 +118,7 @@ def test_aws_api_gateway_scope_basic():
         "raw_path": None,
         "root_path": "",
         "scheme": "https",
-        "server": ("mangum", 80),
+        "server": ("70ixmpl4fl.execute-api.us-east-2.amazonaws.com", 80),
         "type": "http",
     }
 

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -47,8 +47,8 @@ def get_mock_aws_api_gateway_event(
                 "cognitoAuthenticationType": "",
                 "cognitoAuthenticationProvider": "",
                 "userArn": "",
-                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
-                # noqa: E501
+                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
                 "user": "",
             },
             "resourcePath": "/{proxy+}",
@@ -118,7 +118,8 @@ def test_aws_api_gateway_scope_basic():
             [b"host", b"70ixmpl4fl.execute-api.us-east-2.amazonaws.com"],
             [
                 b"user-agent",
-                b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 "
+                b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                b"Chrome/80.0.3987.132 "
                 b"Safari/537.36",
             ],
             [b"x-amzn-trace-id", b"Root=1-5e66d96f-7491f09xmpl79d18acf3d050"],

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -47,7 +47,8 @@ def get_mock_aws_api_gateway_event(
                 "cognitoAuthenticationType": "",
                 "cognitoAuthenticationProvider": "",
                 "userArn": "",
-                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) "
+                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
                 "user": "",
             },
@@ -76,17 +77,20 @@ def test_aws_api_gateway_scope_basic():
         "httpMethod": "GET",
         "requestContext": {"resourcePath": "/", "httpMethod": "GET", "path": "/Prod/"},
         "headers": {
-            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
+            "accept": "text/html,application/xhtml+xml,application/xml;"
+            "q=0.9,image/webp,image/apng,*/*;q=0.8,"
             "application/signed-exchange;v=b3;q=0.9",
             "accept-encoding": "gzip, deflate, br",
             "Host": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/80.0.3987.132 Safari/537.36",
             "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
         },
         "multiValueHeaders": {
             "accept": [
-                "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
+                "text/html,application/xhtml+xml,application/xml;"
+                "q=0.9,image/webp,image/apng,*/*;q=0.8,"
                 "application/signed-exchange;v=b3;q=0.9"
             ],
             "accept-encoding": ["gzip, deflate, br"],
@@ -111,14 +115,16 @@ def test_aws_api_gateway_scope_basic():
         "headers": [
             [
                 b"accept",
-                b"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
+                b"text/html,application/xhtml+xml,application/xml;"
+                b"q=0.9,image/webp,image/apng,*/*;q=0.8,"
                 b"application/signed-exchange;v=b3;q=0.9",
             ],
             [b"accept-encoding", b"gzip, deflate, br"],
             [b"host", b"70ixmpl4fl.execute-api.us-east-2.amazonaws.com"],
             [
                 b"user-agent",
-                b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                b"AppleWebKit/537.36 (KHTML, like Gecko) "
                 b"Chrome/80.0.3987.132 "
                 b"Safari/537.36",
             ],

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -47,7 +47,8 @@ def get_mock_aws_api_gateway_event(
                 "cognitoAuthenticationType": "",
                 "cognitoAuthenticationProvider": "",
                 "userArn": "",
-                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",  # noqa: E501
+                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+                # noqa: E501
                 "user": "",
             },
             "resourcePath": "/{proxy+}",
@@ -75,15 +76,18 @@ def test_aws_api_gateway_scope_basic():
         "httpMethod": "GET",
         "requestContext": {"resourcePath": "/", "httpMethod": "GET", "path": "/Prod/"},
         "headers": {
-            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",  # noqa: E501
+            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
+            "application/signed-exchange;v=b3;q=0.9",
             "accept-encoding": "gzip, deflate, br",
             "Host": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",  # noqa: E501
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/80.0.3987.132 Safari/537.36",
             "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
         },
         "multiValueHeaders": {
             "accept": [
-                "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"  # noqa: E501
+                "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
+                "application/signed-exchange;v=b3;q=0.9 "
             ],
             "accept-encoding": ["gzip, deflate, br"],
         },
@@ -105,11 +109,19 @@ def test_aws_api_gateway_scope_basic():
         "aws.eventType": "AWS_API_GATEWAY",
         "client": (None, 0),
         "headers": [
-            [b"accept", b"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"],  # noqa: E501
+            [
+                b"accept",
+                b"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
+                b"application/signed-exchange;v=b3;q=0.9",
+            ],
             [b"accept-encoding", b"gzip, deflate, br"],
             [b"host", b"70ixmpl4fl.execute-api.us-east-2.amazonaws.com"],
-            [b"user-agent", b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"],  # noqa: E501
-            [b"x-amzn-trace-id", b"Root=1-5e66d96f-7491f09xmpl79d18acf3d050"]
+            [
+                b"user-agent",
+                b"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 "
+                b"Safari/537.36",
+            ],
+            [b"x-amzn-trace-id", b"Root=1-5e66d96f-7491f09xmpl79d18acf3d050"],
         ],
         "http_version": "1.1",
         "method": "GET",

--- a/tests/handlers/test_aws_api_gateway.py
+++ b/tests/handlers/test_aws_api_gateway.py
@@ -87,7 +87,7 @@ def test_aws_api_gateway_scope_basic():
         "multiValueHeaders": {
             "accept": [
                 "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,"
-                "application/signed-exchange;v=b3;q=0.9 "
+                "application/signed-exchange;v=b3;q=0.9"
             ],
             "accept-encoding": ["gzip, deflate, br"],
         },


### PR DESCRIPTION
When calling a Lambda via a AWS API Gateway, you are supposed to be able to use both normal headers and "multiValueHeaders" as described here: ["Multi-value headers as well as single-value headers and parameters can be combined in the same requests and responses."](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#apigateway-multivalue-headers-and-parameters)

I fixed this by simply checking for both keys in the event dict and updating the resulting headers dict first with the normal headers and then with the multiValueHeaders, so they still take precedence.