### PR TITLE
Improve logging

### DIFF
--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -110,9 +110,6 @@ class HTTPCycle:
         Awaited by the application to send ASGI `http` events.
         """
         message_type = message["type"]
-        self.logger.info(
-            "%s:  '%s' event received from application.", self.state, message_type
-        )
 
         if (
             self.state is HTTPCycleState.REQUEST
@@ -142,6 +139,12 @@ class HTTPCycle:
 
                 self.state = HTTPCycleState.COMPLETE
                 await self.app_queue.put({"type": "http.disconnect"})
+
+                self.logger.info(
+                    f'"{self.request.method} {self.request.path} '
+                    f'HTTP {self.request.http_version}" '
+                    f"{self.response.status} {len(self.response.body)}"
+                )
 
         else:
             raise UnexpectedMessage(

--- a/mangum/protocols/websockets.py
+++ b/mangum/protocols/websockets.py
@@ -135,9 +135,6 @@ class WebSocketCycle:
         Awaited by the application to send ASGI `websocket` events.
         """
         message_type = message["type"]
-        self.logger.info(
-            "%s:  '%s' event received from application.", self.state, message_type
-        )
 
         if self.state is WebSocketCycleState.HANDSHAKE and message_type in (
             "websocket.accept",
@@ -191,6 +188,12 @@ class WebSocketCycle:
 
             await self.websocket.post_to_connection(self.connection_id, body=body)
             await self.app_queue.put({"type": "websocket.disconnect", "code": 1000})
+
+            self.logger.info(
+                f'"WS {self.request.path} '
+                f'HTTP {self.request.http_version}" '
+                f"{self.response.status} {len(self.response.body)}"
+            )
 
         else:
             raise UnexpectedMessage(

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -107,3 +107,18 @@ def test_binary_response(
 
     response = handler(mock_ws_send_event, {})
     assert response == {"statusCode": 500}
+
+
+@respx.mock(assert_all_mocked=False)
+def test_websocket_logging(
+    sqlite3_dsn, mock_ws_connect_event, mock_ws_send_event, mock_websocket_app, caplog
+) -> None:
+    handler = Mangum(mock_websocket_app, lifespan="off", dsn=sqlite3_dsn)
+    response = handler(mock_ws_connect_event, {})
+    assert response == {"statusCode": 200}
+
+    del mock_ws_send_event["body"]
+    response = handler(mock_ws_send_event, {})
+    assert response == {"statusCode": 200}
+
+    assert '"WS / HTTP 1.1" 200 0' in caplog.text


### PR DESCRIPTION
Closes #210 .

We could also try to log client ip and timestamp, like Nginx does. But I wasn't sure that would be useful here.
And also this is the minimal implementation, please provide any feedback if for example we need this to be customisable?

