### PR TITLE
Removing Websocket from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mangum is an adapter for using [ASGI](https://asgi.readthedocs.io/en/latest/) ap
 
 ## Features
 
-- API Gateway support for [HTTP](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html), [REST](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html), and [WebSocket](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html) APIs.
+- API Gateway support for [HTTP](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) and [REST](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html) APIs.
 
 - Compatibility with ASGI application frameworks, such as [Starlette](https://www.starlette.io/), [FastAPI](https://fastapi.tiangolo.com/), and [Quart](https://pgjones.gitlab.io/quart/). 
 

--- a/docs/lifespan.md
+++ b/docs/lifespan.md
@@ -48,7 +48,7 @@ Defaults to `auto`.
 
 ## State machine
 
-The `LifespanCycle` is a state machine that handles ASGI `lifespan` events intended to run before and after HTTP and WebSocket requests are handled. 
+The `LifespanCycle` is a state machine that handles ASGI `lifespan` events intended to run before and after HTTP requests are handled. 
 
 ### LifespanCycle
 
@@ -58,7 +58,7 @@ The `LifespanCycle` is a state machine that handles ASGI `lifespan` events inten
 
 #### Context manager
 
-Unlike the `HTTPCycle` and `WebSocketCycle` classes, the `LifespanCycle` is also used as a context manager in the adapter class. If lifespan support is turned off, then the application never enters the lifespan cycle context.
+Unlike the `HTTPCycle` class, the `LifespanCycle` is also used as a context manager in the adapter class. If lifespan support is turned off, then the application never enters the lifespan cycle context.
 
 ```python
  with ExitStack() as stack:


### PR DESCRIPTION
The Websocket support was removed in latest version but it's still mentioned in README and the docs. Should it be removed?

This is just a sample, there are other references to Websocket support.