### PR TITLE
Added text_mime_types argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,7 @@ venv.bak/
 
 # IDE Settings
 .idea/
+.vscode
+.devcontainer
 
 .DS_Store

--- a/docs/adapter.md
+++ b/docs/adapter.md
@@ -7,6 +7,8 @@ handler = Mangum(
     app,
     lifespan="auto",
     api_gateway_base_path=None,
+    custom_handlers=None,
+    text_mime_types=None,
 )
 ```
 

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -55,20 +55,8 @@ class Mangum:
         self.custom_handlers = custom_handlers or []
         self.config = LambdaConfig(
             api_gateway_base_path=api_gateway_base_path or "/",
-            text_mime_types=text_mime_types or [*DEFAULT_TEXT_MIME_TYPES],
+            text_mime_types=text_mime_types or DEFAULT_TEXT_MIME_TYPES,
         )
-
-    @property
-    def api_gateway_base_path(self) -> str:
-        return self.config["api_gateway_base_path"]
-
-    @api_gateway_base_path.setter
-    def api_gateway_base_path(self, value: str) -> None:
-        self.config["api_gateway_base_path"] = value
-
-    @property
-    def text_mime_types(self) -> List[str]:
-        return self.config["text_mime_types"]
 
     def infer(self, event: LambdaEvent, context: LambdaContext) -> LambdaHandler:
         for handler_cls in chain(self.custom_handlers, HANDLERS):

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -55,7 +55,7 @@ class Mangum:
         self.custom_handlers = custom_handlers or []
         self.config = LambdaConfig(
             api_gateway_base_path=api_gateway_base_path or "/",
-            text_mime_types=text_mime_types or DEFAULT_TEXT_MIME_TYPES,
+            text_mime_types=text_mime_types or [*DEFAULT_TEXT_MIME_TYPES],
         )
 
     @property

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -55,7 +55,7 @@ class Mangum:
         self.custom_handlers = custom_handlers or []
         self.config = LambdaConfig(
             api_gateway_base_path=api_gateway_base_path or "/",
-            text_mime_types=text_mime_types or DEFAULT_TEXT_MIME_TYPES,
+            text_mime_types=text_mime_types or [*DEFAULT_TEXT_MIME_TYPES],
         )
 
     def infer(self, event: LambdaEvent, context: LambdaContext) -> LambdaHandler:

--- a/mangum/handlers/alb.py
+++ b/mangum/handlers/alb.py
@@ -1,5 +1,5 @@
 from itertools import islice
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Dict, Generator, List, Tuple
 from urllib.parse import urlencode, unquote, unquote_plus
 
 from mangum.handlers.utils import (
@@ -143,11 +143,7 @@ class ALB:
 
         return scope
 
-    def __call__(
-        self,
-        response: Response,
-        text_mime_types: Optional[List[str]] = None,
-    ) -> dict:
+    def __call__(self, response: Response) -> dict:
         multi_value_headers: Dict[str, List[str]] = {}
         for key, value in response["headers"]:
             lower_key = key.decode().lower()
@@ -157,7 +153,7 @@ class ALB:
 
         finalized_headers = case_mutated_headers(multi_value_headers)
         finalized_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], finalized_headers, text_mime_types
+            response["body"], finalized_headers, self.config["text_mime_types"]
         )
 
         out = {

--- a/mangum/handlers/alb.py
+++ b/mangum/handlers/alb.py
@@ -1,5 +1,5 @@
 from itertools import islice
-from typing import Dict, Generator, List, Tuple
+from typing import Dict, Generator, List, Optional, Tuple
 from urllib.parse import urlencode, unquote, unquote_plus
 
 from mangum.handlers.utils import (
@@ -143,7 +143,11 @@ class ALB:
 
         return scope
 
-    def __call__(self, response: Response) -> dict:
+    def __call__(
+        self,
+        response: Response,
+        text_mime_types: Optional[List[str]] = None,
+    ) -> dict:
         multi_value_headers: Dict[str, List[str]] = {}
         for key, value in response["headers"]:
             lower_key = key.decode().lower()
@@ -153,7 +157,7 @@ class ALB:
 
         finalized_headers = case_mutated_headers(multi_value_headers)
         finalized_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], finalized_headers
+            response["body"], finalized_headers, text_mime_types
         )
 
         out = {

--- a/mangum/handlers/api_gateway.py
+++ b/mangum/handlers/api_gateway.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 from urllib.parse import urlencode
 
 from mangum.handlers.utils import (
@@ -110,16 +110,12 @@ class APIGateway:
             "aws.context": self.context,
         }
 
-    def __call__(
-        self,
-        response: Response,
-        text_mime_types: Optional[List[str]] = None,
-    ) -> dict:
+    def __call__(self, response: Response) -> dict:
         finalized_headers, multi_value_headers = handle_multi_value_headers(
             response["headers"]
         )
         finalized_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], finalized_headers, text_mime_types
+            response["body"], finalized_headers, self.config["text_mime_types"]
         )
 
         return {
@@ -200,11 +196,7 @@ class HTTPGateway:
             "aws.context": self.context,
         }
 
-    def __call__(
-        self,
-        response: Response,
-        text_mime_types: Optional[List[str]] = None,
-    ) -> dict:
+    def __call__(self, response: Response) -> dict:
         if self.scope["aws.event"]["version"] == "2.0":
             finalized_headers, cookies = _combine_headers_v2(response["headers"])
 
@@ -212,7 +204,7 @@ class HTTPGateway:
                 finalized_headers["content-type"] = "application/json"
 
             finalized_body, is_base64_encoded = handle_base64_response_body(
-                response["body"], finalized_headers, text_mime_types
+                response["body"], finalized_headers, self.config["text_mime_types"]
             )
             response_out = {
                 "statusCode": response["status"],
@@ -229,7 +221,7 @@ class HTTPGateway:
             response["headers"]
         )
         finalized_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], finalized_headers, text_mime_types
+            response["body"], finalized_headers, self.config["text_mime_types"]
         )
         return {
             "statusCode": response["status"],

--- a/mangum/handlers/api_gateway.py
+++ b/mangum/handlers/api_gateway.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlencode
 
 from mangum.handlers.utils import (
@@ -110,12 +110,16 @@ class APIGateway:
             "aws.context": self.context,
         }
 
-    def __call__(self, response: Response) -> dict:
+    def __call__(
+        self,
+        response: Response,
+        text_mime_types: Optional[List[str]] = None,
+    ) -> dict:
         finalized_headers, multi_value_headers = handle_multi_value_headers(
             response["headers"]
         )
         finalized_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], finalized_headers
+            response["body"], finalized_headers, text_mime_types
         )
 
         return {
@@ -196,7 +200,11 @@ class HTTPGateway:
             "aws.context": self.context,
         }
 
-    def __call__(self, response: Response) -> dict:
+    def __call__(
+        self,
+        response: Response,
+        text_mime_types: Optional[List[str]] = None,
+    ) -> dict:
         if self.scope["aws.event"]["version"] == "2.0":
             finalized_headers, cookies = _combine_headers_v2(response["headers"])
 
@@ -204,7 +212,7 @@ class HTTPGateway:
                 finalized_headers["content-type"] = "application/json"
 
             finalized_body, is_base64_encoded = handle_base64_response_body(
-                response["body"], finalized_headers
+                response["body"], finalized_headers, text_mime_types
             )
             response_out = {
                 "statusCode": response["status"],
@@ -221,7 +229,7 @@ class HTTPGateway:
             response["headers"]
         )
         finalized_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], finalized_headers
+            response["body"], finalized_headers, text_mime_types
         )
         return {
             "statusCode": response["status"],

--- a/mangum/handlers/lambda_at_edge.py
+++ b/mangum/handlers/lambda_at_edge.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from mangum.handlers.utils import (
     handle_base64_response_body,
@@ -76,14 +76,10 @@ class LambdaAtEdge:
             "aws.context": self.context,
         }
 
-    def __call__(
-        self,
-        response: Response,
-        text_mime_types: Optional[List[str]] = None,
-    ) -> dict:
+    def __call__(self, response: Response) -> dict:
         multi_value_headers, _ = handle_multi_value_headers(response["headers"])
         response_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], multi_value_headers, text_mime_types
+            response["body"], multi_value_headers, self.config["text_mime_types"]
         )
         finalized_headers: Dict[str, List[Dict[str, str]]] = {
             key.decode().lower(): [{"key": key.decode().lower(), "value": val.decode()}]

--- a/mangum/handlers/lambda_at_edge.py
+++ b/mangum/handlers/lambda_at_edge.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from mangum.handlers.utils import (
     handle_base64_response_body,
@@ -76,10 +76,14 @@ class LambdaAtEdge:
             "aws.context": self.context,
         }
 
-    def __call__(self, response: Response) -> dict:
+    def __call__(
+        self,
+        response: Response,
+        text_mime_types: Optional[List[str]] = None,
+    ) -> dict:
         multi_value_headers, _ = handle_multi_value_headers(response["headers"])
         response_body, is_base64_encoded = handle_base64_response_body(
-            response["body"], multi_value_headers
+            response["body"], multi_value_headers, text_mime_types
         )
         finalized_headers: Dict[str, List[Dict[str, str]]] = {
             key.decode().lower(): [{"key": key.decode().lower(), "value": val.decode()}]

--- a/mangum/handlers/utils.py
+++ b/mangum/handlers/utils.py
@@ -1,18 +1,8 @@
 import base64
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 from urllib.parse import unquote
 
 from mangum.types import Headers
-
-
-DEFAULT_TEXT_MIME_TYPES = [
-    "text/",
-    "application/json",
-    "application/javascript",
-    "application/xml",
-    "application/vnd.api+json",
-    "application/vnd.oai.openapi",
-]
 
 
 def maybe_encode_body(body: Union[str, bytes], *, is_base64: bool) -> bytes:
@@ -73,12 +63,12 @@ def handle_multi_value_headers(
 def handle_base64_response_body(
     body: bytes,
     headers: Dict[str, str],
-    text_mime_types: Optional[List[str]] = None,
+    text_mime_types: List[str],
 ) -> Tuple[str, bool]:
     is_base64_encoded = False
     output_body = ""
     if body != b"":
-        for text_mime_type in text_mime_types or DEFAULT_TEXT_MIME_TYPES:
+        for text_mime_type in text_mime_types:
             if text_mime_type in headers.get("content-type", ""):
                 try:
                     output_body = body.decode()

--- a/mangum/handlers/utils.py
+++ b/mangum/handlers/utils.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import unquote
 
 from mangum.types import Headers
@@ -71,12 +71,14 @@ def handle_multi_value_headers(
 
 
 def handle_base64_response_body(
-    body: bytes, headers: Dict[str, str]
+    body: bytes,
+    headers: Dict[str, str],
+    text_mime_types: Optional[List[str]] = None,
 ) -> Tuple[str, bool]:
     is_base64_encoded = False
     output_body = ""
     if body != b"":
-        for text_mime_type in DEFAULT_TEXT_MIME_TYPES:
+        for text_mime_type in text_mime_types or DEFAULT_TEXT_MIME_TYPES:
             if text_mime_type in headers.get("content-type", ""):
                 try:
                     output_body = body.decode()

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -136,5 +136,9 @@ class LambdaHandler(Protocol):
     def scope(self) -> Scope:
         ...  # pragma: no cover
 
-    def __call__(self, response: Response) -> dict:
+    def __call__(
+        self,
+        response: Response,
+        text_mime_types: Optional[List[str]] = None,
+    ) -> dict:
         ...  # pragma: no cover

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -116,6 +116,7 @@ class Response(TypedDict):
 
 class LambdaConfig(TypedDict):
     api_gateway_base_path: str
+    text_mime_types: List[str]
 
 
 class LambdaHandler(Protocol):
@@ -136,9 +137,5 @@ class LambdaHandler(Protocol):
     def scope(self) -> Scope:
         ...  # pragma: no cover
 
-    def __call__(
-        self,
-        response: Response,
-        text_mime_types: Optional[List[str]] = None,
-    ) -> dict:
+    def __call__(self, response: Response) -> dict:
         ...  # pragma: no cover

--- a/tests/handlers/test_alb.py
+++ b/tests/handlers/test_alb.py
@@ -331,3 +331,44 @@ def test_aws_alb_response(
         "headers": {"content-type": content_type.decode()},
         "body": res_body,
     }
+
+
+def test_aws_alb_response_extra_mime_types():
+    content_type = b"application/x-yaml"
+    utf_res_body = "name: 'John Doe'"
+    raw_res_body = utf_res_body.encode()
+    b64_res_body = "bmFtZTogJ0pvaG4gRG9lJw=="
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", content_type]],
+            }
+        )
+        await send({"type": "http.response.body", "body": raw_res_body})
+
+    event = get_mock_aws_alb_event("GET", "/test", {}, None, None, False, False)
+
+    # Test default behavior
+    handler = Mangum(app, lifespan="off")
+    response = handler(event, {})
+    assert content_type.decode() not in handler.config["text_mime_types"]
+    assert response == {
+        "statusCode": 200,
+        "isBase64Encoded": True,
+        "headers": {"content-type": content_type.decode()},
+        "body": b64_res_body,
+    }
+
+    # Test with modified text mime types
+    handler = Mangum(app, lifespan="off")
+    handler.config["text_mime_types"].append(content_type.decode())
+    response = handler(event, {})
+    assert response == {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "headers": {"content-type": content_type.decode()},
+        "body": utf_res_body,
+    }

--- a/tests/handlers/test_api_gateway.py
+++ b/tests/handlers/test_api_gateway.py
@@ -381,6 +381,7 @@ def test_aws_api_gateway_response_extra_mime_types():
     # Test default behavior
     handler = Mangum(app, lifespan="off")
     response = handler(event, {})
+    assert content_type.decode() not in handler.config["text_mime_types"]
     assert response == {
         "statusCode": 200,
         "isBase64Encoded": True,

--- a/tests/handlers/test_api_gateway.py
+++ b/tests/handlers/test_api_gateway.py
@@ -391,7 +391,7 @@ def test_aws_api_gateway_response_extra_mime_types():
 
     # Test with modified text mime types
     handler = Mangum(app, lifespan="off")
-    handler.text_mime_types.append(content_type.decode())
+    handler.config["text_mime_types"].append(content_type.decode())
     response = handler(event, {})
     assert response == {
         "statusCode": 200,

--- a/tests/handlers/test_lambda_at_edge.py
+++ b/tests/handlers/test_lambda_at_edge.py
@@ -297,3 +297,48 @@ def test_aws_lambda_at_edge_response(
         },
         "body": res_body,
     }
+
+
+def test_aws_lambda_at_edge_response_extra_mime_types():
+    content_type = b"application/x-yaml"
+    utf_res_body = "name: 'John Doe'"
+    raw_res_body = utf_res_body.encode()
+    b64_res_body = "bmFtZTogJ0pvaG4gRG9lJw=="
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", content_type]],
+            }
+        )
+        await send({"type": "http.response.body", "body": raw_res_body})
+
+    event = mock_lambda_at_edge_event("POST", "/test", {}, None, False)
+
+    # Test default behavior
+    handler = Mangum(app, lifespan="off")
+    response = handler(event, {})
+    assert content_type.decode() not in handler.config["text_mime_types"]
+    assert response == {
+        "status": 200,
+        "isBase64Encoded": True,
+        "headers": {
+            "content-type": [{"key": "content-type", "value": content_type.decode()}]
+        },
+        "body": b64_res_body,
+    }
+
+    # Test with modified text mime types
+    handler = Mangum(app, lifespan="off")
+    handler.config["text_mime_types"].append(content_type.decode())
+    response = handler(event, {})
+    assert response == {
+        "status": 200,
+        "isBase64Encoded": False,
+        "headers": {
+            "content-type": [{"key": "content-type", "value": content_type.decode()}]
+        },
+        "body": utf_res_body,
+    }

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,7 +1,8 @@
 import pytest
 
-from mangum.exceptions import ConfigurationError
 from mangum import Mangum
+from mangum.adapter import DEFAULT_TEXT_MIME_TYPES
+from mangum.exceptions import ConfigurationError
 
 
 async def app(scope, receive, send):
@@ -12,6 +13,21 @@ def test_default_settings():
     handler = Mangum(app)
     assert handler.lifespan == "auto"
     assert handler.api_gateway_base_path == "/"
+    assert sorted(handler.text_mime_types) == sorted(DEFAULT_TEXT_MIME_TYPES)
+
+
+def test_default_settings_mutation():
+    handler = Mangum(app)
+
+    # API gateway base path
+    assert handler.api_gateway_base_path == "/"
+    new_base_path = "/prefix/"
+    handler.api_gateway_base_path = new_base_path
+    assert (
+        handler.api_gateway_base_path
+        == handler.config["api_gateway_base_path"]
+        == new_base_path
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -12,22 +12,8 @@ async def app(scope, receive, send):
 def test_default_settings():
     handler = Mangum(app)
     assert handler.lifespan == "auto"
-    assert handler.api_gateway_base_path == "/"
-    assert sorted(handler.text_mime_types) == sorted(DEFAULT_TEXT_MIME_TYPES)
-
-
-def test_default_settings_mutation():
-    handler = Mangum(app)
-
-    # API gateway base path
-    assert handler.api_gateway_base_path == "/"
-    new_base_path = "/prefix/"
-    handler.api_gateway_base_path = new_base_path
-    assert (
-        handler.api_gateway_base_path
-        == handler.config["api_gateway_base_path"]
-        == new_base_path
-    )
+    assert handler.config["api_gateway_base_path"] == "/"
+    assert sorted(handler.config["text_mime_types"]) == sorted(DEFAULT_TEXT_MIME_TYPES)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added optional `text_mime_types` argument to:
- `Mangum` adapter's `__init__` method
- `handle_base64_response_body` function (this function is the target recipient of the `text_mime_types` list)

This argument is optional and by default references the same `DEFAULT_TEXT_MIME_TYPES` list.

**WARNING**: old solutions involving editing the `DEFAULT_TEXT_MIME_TYPES` list are now broken because this list was moved from `mangum/handlers/utils.py` to `mangum/adapter.py`.

resolves #275