### PR TITLE
Add cached properties

### DIFF
--- a/mangum/handlers/alb.py
+++ b/mangum/handlers/alb.py
@@ -7,6 +7,7 @@ from mangum.handlers.utils import (
     handle_base64_response_body,
     handle_exclude_headers,
     maybe_encode_body,
+    TypedCachedProperty,
 )
 from mangum.types import (
     Response,
@@ -95,16 +96,15 @@ class ALB:
         self.context = context
         self.config = config
 
-    @property
+    @TypedCachedProperty
     def body(self) -> bytes:
         return maybe_encode_body(
             self.event.get("body", b""),
             is_base64=self.event.get("isBase64Encoded", False),
         )
 
-    @property
+    @TypedCachedProperty
     def scope(self) -> Scope:
-
         headers = transform_headers(self.event)
         list_headers = [list(x) for x in headers]
         # Unique headers. If there are duplicates, it will use the last defined.

--- a/mangum/handlers/api_gateway.py
+++ b/mangum/handlers/api_gateway.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Tuple
 from urllib.parse import urlencode
-
 from mangum.handlers.utils import (
     get_server_and_port,
     handle_base64_response_body,
@@ -8,6 +7,7 @@ from mangum.handlers.utils import (
     handle_multi_value_headers,
     maybe_encode_body,
     strip_api_gateway_path,
+    TypedCachedProperty,
 )
 from mangum.types import (
     Response,
@@ -78,14 +78,14 @@ class APIGateway:
         self.context = context
         self.config = config
 
-    @property
+    @TypedCachedProperty
     def body(self) -> bytes:
         return maybe_encode_body(
             self.event.get("body", b""),
             is_base64=self.event.get("isBase64Encoded", False),
         )
 
-    @property
+    @TypedCachedProperty
     def scope(self) -> Scope:
         headers = _handle_multi_value_headers_for_request(self.event)
         return {
@@ -144,14 +144,14 @@ class HTTPGateway:
         self.context = context
         self.config = config
 
-    @property
+    @TypedCachedProperty
     def body(self) -> bytes:
         return maybe_encode_body(
             self.event.get("body", b""),
             is_base64=self.event.get("isBase64Encoded", False),
         )
 
-    @property
+    @TypedCachedProperty
     def scope(self) -> Scope:
         request_context = self.event["requestContext"]
         event_version = self.event["version"]

--- a/mangum/handlers/lambda_at_edge.py
+++ b/mangum/handlers/lambda_at_edge.py
@@ -1,10 +1,10 @@
 from typing import Dict, List
-
 from mangum.handlers.utils import (
     handle_base64_response_body,
     handle_exclude_headers,
     handle_multi_value_headers,
     maybe_encode_body,
+    TypedCachedProperty,
 )
 from mangum.types import Scope, Response, LambdaConfig, LambdaEvent, LambdaContext
 
@@ -31,7 +31,7 @@ class LambdaAtEdge:
         self.context = context
         self.config = config
 
-    @property
+    @TypedCachedProperty
     def body(self) -> bytes:
         cf_request_body = self.event["Records"][0]["cf"]["request"].get("body", {})
         return maybe_encode_body(
@@ -39,7 +39,7 @@ class LambdaAtEdge:
             is_base64=cf_request_body.get("encoding", "") == "base64",
         )
 
-    @property
+    @TypedCachedProperty
     def scope(self) -> Scope:
         cf_request = self.event["Records"][0]["cf"]["request"]
         scheme_header = cf_request["headers"].get("cloudfront-forwarded-proto", [{}])

--- a/mangum/handlers/utils.py
+++ b/mangum/handlers/utils.py
@@ -1,8 +1,11 @@
 import base64
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union, TypeVar, Callable, cast
 from urllib.parse import unquote
-
+from cached_property import cached_property
 from mangum.types import Headers, LambdaConfig
+
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 def maybe_encode_body(body: Union[str, bytes], *, is_base64: bool) -> bytes:
@@ -93,3 +96,8 @@ def handle_exclude_headers(
         finalized_headers[header_key] = header_value
 
     return finalized_headers
+
+
+class TypedCachedProperty(cached_property):
+    def __init__(self, func: F) -> None:
+        super().__init__(func)

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -93,7 +93,6 @@ class HTTPCycle:
             self.state is HTTPCycleState.RESPONSE
             and message["type"] == "http.response.body"
         ):
-
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
             self.buffer.write(body)

--- a/mangum/protocols/lifespan.py
+++ b/mangum/protocols/lifespan.py
@@ -98,14 +98,12 @@ class LifespanCycle:
     async def receive(self) -> Message:
         """Awaited by the application to receive ASGI `lifespan` events."""
         if self.state is LifespanCycleState.CONNECTING:
-
             # Connection established. The next event returned by the queue will be
             # `lifespan.startup` to inform the application that the connection is
             # ready to receive lfiespan messages.
             self.state = LifespanCycleState.STARTUP
 
         elif self.state is LifespanCycleState.STARTUP:
-
             # Connection shutting down. The next event returned by the queue will be
             # `lifespan.shutdown` to inform the application that the connection is now
             # closing so that it may perform cleanup.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ brotli
 brotli-asgi
 mkdocs
 mkdocs-material
+cached-property


### PR DESCRIPTION
Cache properties to prevent methods from invoking multiple times per request

During debugging, I noticed multiple references of a handler's `scope` property (method) would re-invoke it entirely for the same request.